### PR TITLE
Added null `featuredImage` test

### DIFF
--- a/tests/wpunit/PostObjectQueriesTest.php
+++ b/tests/wpunit/PostObjectQueriesTest.php
@@ -302,7 +302,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @since 0.0.5
 	 */
-	public function testPostQueryWithComments() {
+	public function testPostQueryWithCommentsAndNoFeaturedImage() {
 
 		/**
 		 * Create a post
@@ -337,6 +337,9 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 						}
 					}
 				}
+				featuredImage {
+					id
+				}
 			}
 		}";
 
@@ -363,6 +366,7 @@ class PostObjectQueriesTest extends \Codeception\TestCase\WPTestCase {
 					],
 					'commentCount'  => 1,
 					'commentStatus' => 'open',
+					'featuredImage' => null,
 				],
 			],
 		];


### PR DESCRIPTION
I made a change to `testPostQueryWithCommentsAndNoFeaturedImage` to confirm that featuredImage returns a null and no break the query with one is on the post.

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
…


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
