### PR TITLE
feat: Add $source, $args, $context, $info to all filters to be more consistent

### DIFF
--- a/src/Data/Connection/AbstractConnectionResolver.php
+++ b/src/Data/Connection/AbstractConnectionResolver.php
@@ -404,7 +404,6 @@ abstract class AbstractConnectionResolver {
 	 * @throws Exception if child class forgot to implement this.
 	 *
 	 * @since 1.9.0
-	 *
 	 */
 	public function get_ids_from_query() {
 		throw new Exception( sprintf(
@@ -630,7 +629,6 @@ abstract class AbstractConnectionResolver {
 	 * @deprecated 1.9.0
 	 *
 	 * @codeCoverageIgnore
-	 *
 	 */
 	public function get_offset() {
 		_deprecated_function( __METHOD__, '1.9.0', static::class . '::get_offset_for_cursor()' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -771,7 +769,6 @@ abstract class AbstractConnectionResolver {
 	 * @return array
 	 * @throws Exception
 	 * @uses AbstractConnectionResolver::get_ids_for_nodes()
-	 *
 	 */
 	public function get_nodes() {
 		$nodes = [];
@@ -973,9 +970,8 @@ abstract class AbstractConnectionResolver {
 		 * @param array                      $args                array of arguments input in the field as part of the GraphQL query
 		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree
 		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree
-		 *
 		 */
-		$this->query = apply_filters( 'graphql_connection_query', $this->get_query(), $this, $this->source, $this->args, $this->context, $this->info  );
+		$this->query = apply_filters( 'graphql_connection_query', $this->get_query(), $this, $this->source, $this->args, $this->context, $this->info );
 
 		/**
 		 * Filter the connection IDs
@@ -986,7 +982,6 @@ abstract class AbstractConnectionResolver {
 		 * @param array                      $args                array of arguments input in the field as part of the GraphQL query
 		 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree
 		 * @param ResolveInfo                $info                Info about fields passed down the resolve tree
-		 *
 		 */
 		$this->ids = apply_filters( 'graphql_connection_ids', $this->get_ids(), $this, $this->source, $this->args, $this->context, $this->info );
 
@@ -1021,7 +1016,7 @@ abstract class AbstractConnectionResolver {
 		 * returning the connection.
 		 */
 		return new Deferred(
-			function() {
+			function () {
 
 				if ( ! empty( $this->ids ) ) {
 					$this->loader->load_many( $this->ids );
@@ -1038,7 +1033,6 @@ abstract class AbstractConnectionResolver {
 				 * @param array                      $args                array of arguments input in the field as part of the GraphQL query
 				 * @param AppContext                 $context             Object containing app context that gets passed down the resolve tree
 				 * @param ResolveInfo                $info                Info about fields passed down the resolve tree
-				 *
 				 */
 				$this->nodes = apply_filters( 'graphql_connection_nodes', $this->get_nodes(), $this, $this->source, $this->args, $this->context, $this->info );
 

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -257,10 +257,14 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @param array                     $args                The GraphQL args passed to the resolver.
 		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
-		 *
+		 * @param mixed                     $source              source passed down from the resolve tree
+		 * @param array                     $args                array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext                $context             object passed down the resolve tree
+		 * @param ResolveInfo               $info                info about fields passed down the resolve tree
+
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_comment_connection_args', $args, $this );
+		return apply_filters( 'graphql_comment_connection_args', $args, $this, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/CommentConnectionResolver.php
+++ b/src/Data/Connection/CommentConnectionResolver.php
@@ -252,19 +252,19 @@ class CommentConnectionResolver extends AbstractConnectionResolver {
 		}
 
 		/**
-		 *
 		 * Filters the GraphQL args before they are used in get_query_args().
 		 *
 		 * @param array                     $args                The GraphQL args passed to the resolver.
 		 * @param CommentConnectionResolver $connection_resolver Instance of the ConnectionResolver
 		 * @param mixed                     $source              source passed down from the resolve tree
-		 * @param array                     $args                array of arguments input in the field as part of the GraphQL query
+		 * @param array                     $original_args       array of arguments input in the field as part of the GraphQL query
 		 * @param AppContext                $context             object passed down the resolve tree
 		 * @param ResolveInfo               $info                info about fields passed down the resolve tree
 
 		 * @since 1.11.0
 		 */
 		return apply_filters( 'graphql_comment_connection_args', $args, $this, $this->source, $this->args, $this->context, $this->info );
+
 	}
 
 	/**

--- a/src/Data/Connection/ContentTypeConnectionResolver.php
+++ b/src/Data/Connection/ContentTypeConnectionResolver.php
@@ -1,6 +1,9 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class ContentTypeConnectionResolver
  *
@@ -37,8 +40,20 @@ class ContentTypeConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
-		return [];
+
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_content_type_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace WPGraphQL\Data\Connection;
 
 use Exception;
@@ -15,10 +16,12 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	/**
 	 * EnqueuedScriptsConnectionResolver constructor.
 	 *
-	 * @param mixed       $source     source passed down from the resolve tree
-	 * @param array       $args       array of arguments input in the field as part of the GraphQL query
-	 * @param AppContext  $context    Object containing app context that gets passed down the resolve tree
-	 * @param ResolveInfo $info       Info about fields passed down the resolve tree
+	 * @param mixed       $source  source passed down from the resolve tree
+	 * @param array       $args    array of arguments input in the field as part of the GraphQL
+	 *                             query
+	 * @param AppContext  $context Object containing app context that gets passed down the resolve
+	 *                             tree
+	 * @param ResolveInfo $info    Info about fields passed down the resolve tree
 	 *
 	 * @throws Exception
 	 */
@@ -27,10 +30,11 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', function( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
 				return 1000;
 			}
+
 			return $max;
 		}, 10, 5 );
 
@@ -60,8 +64,19 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
-		return [];
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_enqueued_scripts_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 
@@ -70,7 +85,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 *
 	 * @return array
 	 */
-	public function get_query() {
+	public function get_query(): array {
 		return $this->source->enqueuedScriptsQueue ? $this->source->enqueuedScriptsQueue : [];
 	}
 
@@ -103,6 +118,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 	 */
 	public function is_valid_offset( $offset ) {
 		global $wp_scripts;
+
 		return isset( $wp_scripts->registered[ $offset ] );
 	}
 

--- a/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedScriptsConnectionResolver.php
@@ -30,7 +30,7 @@ class EnqueuedScriptsConnectionResolver extends AbstractConnectionResolver {
 		/**
 		 * Filter the query amount to be 1000 for
 		 */
-		add_filter( 'graphql_connection_max_query_amount', function( $max, $source, $args, $context, ResolveInfo $info ) {
+		add_filter( 'graphql_connection_max_query_amount', function ( $max, $source, $args, $context, ResolveInfo $info ) {
 			if ( 'enqueuedScripts' === $info->fieldName || 'registeredScripts' === $info->fieldName ) {
 				return 1000;
 			}

--- a/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
+++ b/src/Data/Connection/EnqueuedStylesheetConnectionResolver.php
@@ -68,8 +68,19 @@ class EnqueuedStylesheetConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
-		return [];
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_enqueued_stylesheets_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 

--- a/src/Data/Connection/MenuConnectionResolver.php
+++ b/src/Data/Connection/MenuConnectionResolver.php
@@ -3,6 +3,8 @@
 namespace WPGraphQL\Data\Connection;
 
 use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 
 /**
  * Class MenuConnectionResolver
@@ -47,7 +49,21 @@ class MenuConnectionResolver extends TermObjectConnectionResolver {
 
 		$query_args = parent::get_query_args();
 
-		return array_merge( $query_args, $term_args );
+		$query_args = array_merge( $query_args, $term_args );
+
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_menu_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 }

--- a/src/Data/Connection/MenuItemConnectionResolver.php
+++ b/src/Data/Connection/MenuItemConnectionResolver.php
@@ -88,7 +88,19 @@ class MenuItemConnectionResolver extends PostObjectConnectionResolver {
 			];
 		}
 
-		return $query_args;
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_menu_item_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/PluginConnectionResolver.php
+++ b/src/Data/Connection/PluginConnectionResolver.php
@@ -1,6 +1,9 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class PluginConnectionResolver - Connects plugins to other objects
  *
@@ -37,13 +40,28 @@ class PluginConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
+
+		$query_args = $this->args;
+
 		if ( ! empty( $this->args['where']['status'] ) ) {
-			$this->args['where']['stati'] = [ $this->args['where']['status'] ];
+			$query_args['where']['stati'] = [ $this->args['where']['status'] ];
 		} elseif ( ! empty( $this->args['where']['stati'] ) && is_string( $this->args['where']['stati'] ) ) {
-			$this->args['where']['stati'] = [ $this->args['where']['stati'] ];
+			$query_args['where']['stati'] = [ $this->args['where']['stati'] ];
 		}
 
-		return $this->args;
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_plugin_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/TaxonomyConnectionResolver.php
+++ b/src/Data/Connection/TaxonomyConnectionResolver.php
@@ -1,6 +1,9 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class TaxonomyConnectionResolver
  *
@@ -37,8 +40,19 @@ class TaxonomyConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
-		return [];
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_taxonomy_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 

--- a/src/Data/Connection/TermObjectConnectionResolver.php
+++ b/src/Data/Connection/TermObjectConnectionResolver.php
@@ -147,9 +147,7 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @since 0.0.6
 		 */
-		$query_args = apply_filters( 'graphql_term_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
-
-		return $query_args;
+		return apply_filters( 'graphql_term_object_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**
@@ -299,10 +297,14 @@ class TermObjectConnectionResolver extends AbstractConnectionResolver {
 		 *
 		 * @param array                     $args                The GraphQL args passed to the resolver.
 		 * @param TermObjectConnectionResolver $connection_resolver Instance of the ConnectionResolver
+		 * @param mixed                        $source              Source passed down from the resolve tree.
+		 * @param array                        $all_args            Array of arguments input in the field as part of the GraphQL query.
+		 * @param AppContext                   $context             Object containing app context that gets passed down the resolve tree.
+		 * @param ResolveInfo                  $info                Info about fields passed down the resolve tree.
 		 *
 		 * @since 1.11.0
 		 */
-		return apply_filters( 'graphql_term_object_connection_args', $args, $this );
+		return apply_filters( 'graphql_term_object_connection_args', $args, $this, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/ThemeConnectionResolver.php
+++ b/src/Data/Connection/ThemeConnectionResolver.php
@@ -1,6 +1,9 @@
 <?php
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
+
 /**
  * Class ThemeConnectionResolver
  *
@@ -42,7 +45,19 @@ class ThemeConnectionResolver extends AbstractConnectionResolver {
 			'allowed' => null,
 		];
 
-		return $query_args;
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_theme_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 

--- a/src/Data/Connection/UserConnectionResolver.php
+++ b/src/Data/Connection/UserConnectionResolver.php
@@ -171,7 +171,19 @@ class UserConnectionResolver extends AbstractConnectionResolver {
 			$query_args['order'] = ! empty( $last ) ? 'DESC' : 'ASC';
 		}
 
-		return $query_args;
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_user_connection_query_args', $query_args, $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**

--- a/src/Data/Connection/UserRoleConnectionResolver.php
+++ b/src/Data/Connection/UserRoleConnectionResolver.php
@@ -2,6 +2,8 @@
 
 namespace WPGraphQL\Data\Connection;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\AppContext;
 use WPGraphQL\Model\User;
 
 /**
@@ -46,8 +48,19 @@ class UserRoleConnectionResolver extends AbstractConnectionResolver {
 	 * {@inheritDoc}
 	 */
 	public function get_query_args() {
-		// If any args are added to filter/sort the connection
-		return [];
+		/**
+		 * Filter the query_args that should be applied to the query. This filter is applied AFTER the input args from
+		 * the GraphQL Query have been applied and has the potential to override the GraphQL Query Input Args.
+		 *
+		 * @param array       $query_args array of query_args being passed to the
+		 * @param mixed       $source     source passed down from the resolve tree
+		 * @param array       $args       array of arguments input in the field as part of the GraphQL query
+		 * @param AppContext  $context    object passed down the resolve tree
+		 * @param ResolveInfo $info       info about fields passed down the resolve tree
+		 *
+		 * @since 0.0.6
+		 */
+		return apply_filters( 'graphql_user_role_connection_query_args', [], $this->source, $this->args, $this->context, $this->info );
 	}
 
 	/**


### PR DESCRIPTION
This PR updates more filters across connection resolvers to be more consistent with each other, and pass more args ($source, $args, $context, $info) down to the filters